### PR TITLE
Refactor schema functions to include payload type

### DIFF
--- a/fetch-postman-collection.py
+++ b/fetch-postman-collection.py
@@ -4,11 +4,7 @@ import json
 import http.client
 from pathlib import Path
 
-BOILERPLATE = """// Once exported, use this statement in your scripts to use the package:
-// const bedrockTestHelpers = pm.require('@keyholding/bedrock-test-helpers');
-// const schema = bedrockTestHelpers.getEnvelopedSchema({"type": "object"}, pm.request.url.path, pm.request.method);
-
-const getEnvelopedSchema = (schema, urlPath, requestMethod, forcedPayloadReturnType) => {
+BOILERPLATE = """const getEnvelopedSchema = (schema, urlPath, requestMethod, forcedPayloadReturnType) => {
     return getSchemaGeneric(schema, urlPath, requestMethod, true, forcedPayloadReturnType);
 };
 
@@ -139,6 +135,13 @@ const errorsSchema = () => {
             }
         }
     }
+};
+
+const bedrockTestHelpers = {
+    getEnvelopedSchema,
+    getSchema,
+    errorsEnvelopeSchema,
+    errorsSchema
 };"""
 
 BOILERPLATE = [f'"{line.replace('"', '\\"')}",' for line in BOILERPLATE.split("\n")]


### PR DESCRIPTION
# Ticket: [AB#21680](https://dev.azure.com/thekeyholdingcompany/8392b372-a365-443f-980c-0e591853992d/_workitems/edit/21680)

Adding the ability to specify the type of response to expect: i.e. a list or a single object.

* [x] I have reviewed my own code
* [x] Any breaking changes or deprecations have been communicated

# Related PRs

* TheKeyholdingCompany/nessa#300

# Changelog
<!-- (remove any unneeded sections below) -->

## Added
* Ability to force a `"list"` or an `"object"` type response for response schema validation (this matches the package in postman).
