### PR TITLE
call correct schema method from forced payload return type

### DIFF
--- a/fetch-postman-collection.py
+++ b/fetch-postman-collection.py
@@ -16,9 +16,14 @@ const getSchemaGeneric = (schema, urlPath, requestMethod, isEnvelope, forcedPayl
     const doSchema = isEnvelope ? envelopeSchema : s=>s;
     const doListSchema = isEnvelope ? listEnvelopeSchema : listSchema;
     const doDeleteSchema = isEnvelope ? deleteEnvelopeSchema : deleteSchema;
+    
+    if(forcedPayloadReturnType === "object"){
+        return doSchema(schema);
+    }
 
-    const isListRequest = urlIsListRequest(urlPath, forcedPayloadReturnType);
-    if(requestMethod === "GET" && isListRequest){
+    const isListRequest = urlIsListRequest(urlPath);
+
+    if((forcedPayloadReturnType === "list") || (requestMethod === "GET" && isListRequest)){
         return doListSchema(schema);
     }
     if(requestMethod === "DELETE"){
@@ -27,10 +32,7 @@ const getSchemaGeneric = (schema, urlPath, requestMethod, isEnvelope, forcedPayl
     return doSchema(schema);
 }
 
-const urlIsListRequest = (urlPath, forcedPayloadReturnType) => {
-    if (forcedPayloadReturnType && ["list", "object"].includes(forcedPayloadReturnType)){
-        return forcedPayloadReturnType;
-    }
+const urlIsListRequest = (urlPath) => {
     const lastPathItem = urlPath[urlPath.length-1];
     // if the URL doesn't end with a UUID
     return !/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/.test(lastPathItem);


### PR DESCRIPTION
# Ticket: [AB#21680](https://dev.azure.com/thekeyholdingcompany/8392b372-a365-443f-980c-0e591853992d/_workitems/edit/21680)
Describe, in broad terms, what this pull request is achieving

* [x] I have reviewed my own code
* [x] Any breaking changes or deprecations have been communicated

# Related PRs
* [Postman PR]( https://keyholding.postman.co/workspace/8137e0b4-ec7f-40de-863a-eb5975f0b63d/pull-request/911fda4b-6670-4831-9c92-e3c196db9ed9)
* [Nessa#300](https://github.com/TheKeyholdingCompany/nessa/pull/300)

# Changelog
## Fixed
* Correct method is called to provide the schema based on if an forced payload type is passed