### PR TITLE
Add originalData property to schemas

### DIFF
--- a/fetch-postman-collection.py
+++ b/fetch-postman-collection.py
@@ -75,10 +75,12 @@ const envelopeSchema = (schema) => {
                 "items": {
                     "type": "object",
                     "additionalProperties": false,
-                    "required": ["message", "originalException"],
+                    "required": ["code", "error", "message", "exception", "originalException"],
                     "properties": {
+                        "code": {"type": "number"},
                         "error": {"type": "string"},
                         "message": {"type": "string"},
+                        "exception": {"type": "string"},
                         "originalException": {"type": "string"}
                     }
                 }
@@ -88,10 +90,12 @@ const envelopeSchema = (schema) => {
                 "items": {
                     "type": "object",
                     "additionalProperties": false,
-                    "required": ["message", "originalException"],
+                    "required": ["code", "error", "message", "exception", "originalException"],
                     "properties": {
+                        "code": {"type": "number"},
                         "error": {"type": "string"},
                         "message": {"type": "string"},
+                        "exception": {"type": "string"},
                         "originalException": {"type": "string"}
                     }
                 }

--- a/fetch-postman-collection.py
+++ b/fetch-postman-collection.py
@@ -45,6 +45,12 @@ const envelopeSchema = (schema) => {
         "required": ["data", "_metadata"],
         "properties": {
             "data": schema,
+            "originalData": {
+                "anyOf": [
+                    schema,
+                    { "type": "null" }
+                ]
+            },
             "_metadata": {
                 "type": "object",
                 "additionalProperties": false,
@@ -109,11 +115,12 @@ const deleteEnvelopeSchema = (schema) => {
     return {
         "type": "object",
         "additionalProperties": false,
-        "required": ["data", "deleted", "originalObject"],
+        "required": ["data", "deleted", "originalObject", "originalData"],
         "properties": {
             "deleted": {"type": "boolean"},
             "data": {"type": "null"},
             "originalObject": schema,
+            "originalData": schema,
             "message": {"type": "string"}
         }
     }
@@ -123,14 +130,16 @@ const deleteSchema = (schema) => {
     return {
         "type": "object",
         "additionalProperties": false,
-        "required": ["deleted", "originalObject"],
+        "required": ["deleted", "originalObject", "originalData"],
         "properties": {
             "deleted": {"type": "boolean"},
             "originalObject": schema,
+            "originalData": schema,
             "message": {"type": "string"}
         }
     }
 }
+
 
 const errorsEnvelopeSchema = () => {
     return {

--- a/fetch-postman-collection.py
+++ b/fetch-postman-collection.py
@@ -42,7 +42,7 @@ const envelopeSchema = (schema) => {
     return {
         "type": "object",
         "additionalProperties": false,
-        "required": ["data", "_metadata"],
+        "required": ["data", "originalData", "_metadata"],
         "properties": {
             "data": schema,
             "originalData": {

--- a/fetch-postman-collection.py
+++ b/fetch-postman-collection.py
@@ -77,7 +77,7 @@ const envelopeSchema = (schema) => {
                     "additionalProperties": false,
                     "required": ["code", "error", "message", "exception", "originalException"],
                     "properties": {
-                        "code": {"type": "number"},
+                        "code": {"type": "string"},
                         "error": {"type": "string"},
                         "message": {"type": "string"},
                         "exception": {"type": "string"},
@@ -92,7 +92,7 @@ const envelopeSchema = (schema) => {
                     "additionalProperties": false,
                     "required": ["code", "error", "message", "exception", "originalException"],
                     "properties": {
-                        "code": {"type": "number"},
+                        "code": {"type": "string"},
                         "error": {"type": "string"},
                         "message": {"type": "string"},
                         "exception": {"type": "string"},

--- a/fetch-postman-collection.py
+++ b/fetch-postman-collection.py
@@ -140,7 +140,6 @@ const deleteSchema = (schema) => {
     }
 }
 
-
 const errorsEnvelopeSchema = () => {
     return {
         "type": "object",


### PR DESCRIPTION
# Ticket: AB#1234
Added Original Data attribute to bedrock enveloped responses and bedrock deletion responses

* [X] I have reviewed my own code
* [X] Any breaking changes or deprecations have been communicated

These changes were tested by upgrading Bedrock locally on Nessa to 6.1.3 and setting the default response to non enveloped. This is to simulate the configuration which will be used to allow front end the time to implement envelop responses as the default.

# Related PRs
* [Nessa#341](https://github.com/TheKeyholdingCompany/nessa/pull/341)

# Changelog
## Fixed
* Enveloped and deletion responses now include originalData attributes as part of their schema test