### PR TITLE
feat(TKC-0334): add Dependabot config for action-get-postman-collection

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      docker-deps:
+        patterns: ["*"]
+        update-types: ["patch", "minor", "major"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,6 @@ updates:
       docker-deps:
         patterns: ["*"]
         update-types: ["patch", "minor", "major"]
+    cooldown:
+      default-days: 3
+      semver-major-days: 14

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,4 +10,3 @@ updates:
         update-types: ["patch", "minor", "major"]
     cooldown:
       default-days: 3
-      semver-major-days: 14


### PR DESCRIPTION
# Ticket: TKC-0334
Adds Dependabot coverage to action-get-postman-collection, part of the Phase 2 batch-1 rollout (no private registry needed).

* [x] I have reviewed my own code
* [x] Any breaking changes or deprecations have been communicated

# Changelog

## Added
* `.github/dependabot.yml` — docker (root), weekly. No requirements.txt/package.json/terraform, no github-actions workflows exist so that ecosystem was left out.